### PR TITLE
Added check for local development URL.

### DIFF
--- a/source/_includes/piwik_analytics.html
+++ b/source/_includes/piwik_analytics.html
@@ -1,4 +1,5 @@
 {% if site.piwik_url %}
+{% if site.url != "http://localhost:4000" %}
 <!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
@@ -14,4 +15,5 @@
 </script>
 <noscript><p><img src="//{{ site.piwik_url }}/piwik.php?idsite={{ site.piwik_siteid }}" style="border:0;" alt="" /></p></noscript>
 <!-- End Piwik Code -->
+{% endif %}
 {% endif %}


### PR DESCRIPTION
The Piwik tracking code gets only inserted if we are running on
production. Production is everything which does not run on
`http://localhost:4000`.

This URL needs to be defined in the Jekyll call with the `--url` option
like this:

```
jekyll --auto --url 'http://localhost:4000'
```